### PR TITLE
feat: alert banner merge

### DIFF
--- a/src/components/alert/index.tsx
+++ b/src/components/alert/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { HTMLAttributes, useState } from 'react';
 
 import { Flex } from '../flex';
 import { Text } from '../text';
+import { Spacer } from '../spacer';
 import type { ButtonProps } from '../button';
 
 import { DestructiveIcon } from './icons/destructive';
@@ -10,6 +11,8 @@ import { WarningIcon } from './icons/warning';
 import { CloseIcon } from './icons/close';
 
 import * as S from './styles';
+
+import { CSS } from '../../system';
 
 export type AlertProps = {
   /**
@@ -30,12 +33,30 @@ export type AlertProps = {
    */
   variant?: 'primary' | 'destructive' | 'warning' | 'success';
   /**
+   * Icon to display in the alert
+   * @default "true"
+   */
+  dismissible?: boolean;
+  /**
+   * Banner style of the alert
+   * @default "false"
+   */
+  banner?: boolean;
+  /**
+   * Align of the action buttons
+   * @default "end"
+   */
+  align?: 'end' | 'center' | 'start';
+  /**
    * Action buttons of the alert
    */
   children?: React.ReactNode;
-};
+  /**
+   * CSS properties
+   */
+  css?: CSS;
+} & HTMLAttributes<HTMLDivElement>;
 
-//
 const icons = {
   destructive: <DestructiveIcon />,
   success: <SuccessIcon />,
@@ -52,7 +73,10 @@ export const Alert = ({
   subtitle,
   description,
   children,
+  dismissible = true,
   variant,
+  banner,
+  align = 'end',
   ...props
 }: AlertProps) => {
   const [show, setShow] = useState(true);
@@ -60,20 +84,22 @@ export const Alert = ({
     <>
       {show && (
         <S.Wrapper variant={variant} wrap="wrap" gap={3} {...props}>
-          <S.IconWrapper
-            variant={variant}
-            onClick={() => setShow(false)}
-            css={{
-              fontSize: '$lg',
-              position: 'absolute',
-              top: '16px',
-              right: '16px',
-              cursor: 'pointer',
-            }}
-          >
-            <CloseIcon />
-          </S.IconWrapper>
-          {variant && variant !== 'primary' && (
+          {dismissible && (
+            <S.IconWrapper
+              variant={variant}
+              onClick={() => setShow(false)}
+              css={{
+                fontSize: '$lg',
+                position: 'absolute',
+                top: '16px',
+                right: '16px',
+                cursor: 'pointer',
+              }}
+            >
+              <CloseIcon />
+            </S.IconWrapper>
+          )}
+          {!banner && variant && variant !== 'primary' && (
             <Flex css={{ width: '100%', '@sm': { width: 'auto' } }}>
               <S.IconWrapper variant={variant} css={{ fontSize: '$lg' }}>
                 {icons[variant]}
@@ -90,36 +116,35 @@ export const Alert = ({
                 {title}
               </S.Title>
             </Flex>
-            <Flex gap={4} justify="between" wrap="wrap">
-              <Flex
-                gap={1}
-                direction="column"
-                css={{ width: '100%', '@sm': { width: 'auto' } }}
-              >
-                {subtitle && (
-                  <S.Subtitle transform="uppercase" variant={variant}>
-                    {subtitle}
-                  </S.Subtitle>
-                )}
-                {description && (
-                  <Text transform="normal" size="sm" css={{ color: '$white' }}>
-                    {description}
-                  </Text>
-                )}
-              </Flex>
-              <Flex
-                align="end"
-                gap={2}
-                wrap="wrap"
-                css={{ flexGrow: 1, '@sm': { flexGrow: 'unset' } }}
-              >
-                {React.Children.map(children, (child) =>
-                  React.cloneElement(child as React.ReactElement<ButtonProps>, {
-                    fluid: { '@initial': true, '@sm': false },
-                  }),
-                )}
-              </Flex>
+            <Flex
+              gap={1}
+              direction="column"
+              css={{ width: '100%', '@sm': { width: 'auto' } }}
+            >
+              {subtitle && (
+                <S.Subtitle transform="uppercase" variant={variant}>
+                  {subtitle}
+                </S.Subtitle>
+              )}
+              {description && (
+                <Text transform="normal" size="sm" css={{ color: '$white' }}>
+                  {description}
+                </Text>
+              )}
             </Flex>
+          </Flex>
+          <Spacer />
+          <Flex
+            align={align}
+            gap={2}
+            wrap="wrap"
+            css={{ flexGrow: 1, '@sm': { flexGrow: 'unset' } }}
+          >
+            {React.Children.map(children, (child) =>
+              React.cloneElement(child as React.ReactElement<ButtonProps>, {
+                fluid: { '@initial': true, '@sm': false },
+              }),
+            )}
           </Flex>
         </S.Wrapper>
       )}

--- a/src/components/alert/stories.tsx
+++ b/src/components/alert/stories.tsx
@@ -18,6 +18,12 @@ export default {
     description: {
       control: 'text',
     },
+    dismissible: {
+      control: 'boolean',
+    },
+    banner: {
+      control: 'boolean',
+    },
     variant: {
       control: {
         type: 'select',
@@ -45,6 +51,8 @@ Default.args = {
   variant: 'primary',
   subtitle: 'Subtitle',
   description: 'Description',
+  banner: false,
+  dismissible: true,
 };
 
 export const Destructive: Story<AlertProps> = (args) => {

--- a/src/components/spacer/index.tsx
+++ b/src/components/spacer/index.tsx
@@ -1,0 +1,6 @@
+import { styled } from '../../system';
+import { Flex } from '../flex';
+
+export const Spacer = styled(Flex, {
+  flex: 1,
+});

--- a/storybook/stories/getting-started/changelog.stories.mdx
+++ b/storybook/stories/getting-started/changelog.stories.mdx
@@ -4,6 +4,20 @@ import { Meta } from '@storybook/addon-docs';
 
 # CHANGELOG
 
+## December 16, 2021
+
+### Alert
+
+- Merge Banner component with Alert
+- New props:
+  - Dismissible: add or remove the icon to dismiss the alert
+  - Banner: remove the icon from the left side
+  - Align: set the alignment of the action buttons
+
+> **Design**
+
+- Matching Alert component and Banner component. Also Matching the Alert from Settings Page
+
 ## December 15, 2021
 
 ### Alert


### PR DESCRIPTION
## December 16, 2021

### Alert

- Merge Banner component with Alert
- New props:
  - Dismissible: add or remove the icon to dismiss the alert
  - Banner: remove the icon from the left side
  - Align: set the alignment of the action buttons

> **Design**

- Matching Alert component and Banner component. Also Matching the Alert from Settings Page
