### PR TITLE
feat: build in precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install lint-staged
+yarn build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,4 @@
 
 npx --no-install lint-staged
 yarn build
+git add -A .

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
   },
   "lint-staged": {
     "src/**/*": [
-      "yarn lint --fix",
-      "yarn build"
+      "yarn lint --fix"
     ]
   }
 }


### PR DESCRIPTION
This PR is doing some changes in husky and the way that we push the build to the Github.

A dist folder in the git is not the ideal, I have tried using a postinstall script but without success, since tsup isn't generating the right `.d.ts`.

I'll try later, but this PR solves the current problem: we're doing one commit for changes and other with the build.

With this PR will be possible to do only one commit and have both.